### PR TITLE
Fix audio x wav mimetype

### DIFF
--- a/custom_components/speaker_recognition/config_flow.py
+++ b/custom_components/speaker_recognition/config_flow.py
@@ -260,12 +260,7 @@ class SpeakerRecognitionOptionsFlow(OptionsFlow):
     ) -> ConfigFlowResult:
         """Manage main config options."""
         if user_input is not None:
-            import logging
-            _LOGGER = logging.getLogger(__name__)
-            _LOGGER.error(f"DEBUG: user_input = {user_input}")
-            _LOGGER.error(f"DEBUG: voice_samples type = {type(user_input.get(CONF_VOICE_SAMPLES))}")
-            _LOGGER.error(f"DEBUG: voice_samples content = {user_input.get(CONF_VOICE_SAMPLES)}")
-
+            
             return self.async_create_entry(
                 title="",
                 data={

--- a/custom_components/speaker_recognition/config_flow.py
+++ b/custom_components/speaker_recognition/config_flow.py
@@ -61,7 +61,7 @@ async def _build_voice_samples_schema(
                     "required": True,
                     "selector": selector.MediaSelector(
                         selector.MediaSelectorConfig(
-                            multiple=False, #changed this to `False`
+                            multiple=True,
                             accept=["audio/wav", "audio/x-wav", "audio/mpeg"]
                         )
                     ),

--- a/custom_components/speaker_recognition/config_flow.py
+++ b/custom_components/speaker_recognition/config_flow.py
@@ -61,7 +61,8 @@ async def _build_voice_samples_schema(
                     "required": True,
                     "selector": selector.MediaSelector(
                         selector.MediaSelectorConfig(
-                            multiple=True, accept=["audio/wav", "audio/mpeg"]
+                            multiple=False, #changed this to `False`
+                            accept=["audio/wav", "audio/x-wav", "audio/mpeg"]
                         )
                     ),
                 },
@@ -259,6 +260,12 @@ class SpeakerRecognitionOptionsFlow(OptionsFlow):
     ) -> ConfigFlowResult:
         """Manage main config options."""
         if user_input is not None:
+            import logging
+            _LOGGER = logging.getLogger(__name__)
+            _LOGGER.error(f"DEBUG: user_input = {user_input}")
+            _LOGGER.error(f"DEBUG: voice_samples type = {type(user_input.get(CONF_VOICE_SAMPLES))}")
+            _LOGGER.error(f"DEBUG: voice_samples content = {user_input.get(CONF_VOICE_SAMPLES)}")
+
             return self.async_create_entry(
                 title="",
                 data={


### PR DESCRIPTION
This change would add the `audio/x-wav` MIME type as a valid MIME type for the voice_samples file picker.

This change would partially address #1 , but there is still the issue of the error that is preventing addition of voice samples for speaker training.