### PR TITLE
Improve Home Assistant recognition reliability

### DIFF
--- a/custom_components/speaker_recognition/recognition.py
+++ b/custom_components/speaker_recognition/recognition.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+from urllib.parse import unquote
 
 from speaker_recognition import SpeakerRecognitionClient
 from speaker_recognition.models import (
@@ -23,6 +25,71 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_ADDON_URL = "http://localhost:8099"
 
+LOCAL_MEDIA_PREFIX = "media-source://media_source/local/"
+
+
+def _resolve_local_media_path(hass: HomeAssistant, media_content_id: str) -> Path:
+    """Resolve a Home Assistant local media-source ID to a real filesystem path."""
+    if not media_content_id.startswith(LOCAL_MEDIA_PREFIX):
+        raise ValueError(f"Unsupported media_content_id format: {media_content_id}")
+
+    relative_path = unquote(
+        media_content_id.removeprefix(LOCAL_MEDIA_PREFIX)
+    ).lstrip("/")
+
+    if not relative_path:
+        raise ValueError(f"Empty local media path in media_content_id: {media_content_id}")
+
+    candidates = [
+        Path("/media") / relative_path,
+        Path(hass.config.path("media")) / relative_path,
+    ]
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    raise FileNotFoundError(
+        "Could not find selected media file. Tried: "
+        + ", ".join(str(candidate) for candidate in candidates)
+    )
+
+
+def _extract_media_object(sample: dict[str, Any]) -> dict[str, Any] | None:
+    """Extract one media selector object from a configured voice sample.
+
+    The intended shape is:
+
+        {
+            "user": "...",
+            "samples": {
+                "media_content_id": "...",
+                "media_content_type": "...",
+            },
+        }
+
+    Older/broken saved data may contain "samples" as a one-item list because
+    the old MediaSelector used multiple=True. This helper accepts that shape
+    defensively for migration/testing, but rejects zero or multiple media files.
+    """
+    media = sample.get("samples")
+
+    if isinstance(media, list):
+        if len(media) != 1:
+            _LOGGER.warning(
+                "Expected exactly one voice sample media object, got %d",
+                len(media),
+            )
+            return None
+
+        media = media[0]
+
+    if not isinstance(media, dict):
+        _LOGGER.warning("Invalid voice sample media object: %r", media)
+        return None
+
+    return media
+
 
 class SpeakerRecognition:
     """Handle speaker recognition from audio data."""
@@ -36,14 +103,34 @@ class SpeakerRecognition:
         """Initialize speaker recognition.
 
         Args:
-            hass: Home Assistant instance
-            voice_samples: List of voice samples with user and audio file info
-            base_url: Base URL of the speaker recognition service
+            hass: Home Assistant instance.
+            voice_samples: List of voice samples with user and audio file info.
+            base_url: Base URL of the speaker recognition service.
         """
         self.hass = hass
         self.voice_samples = voice_samples
+        self.base_url = base_url
         self._trained = False
         self._client = SpeakerRecognitionClient(base_url=base_url, timeout=300.0)
+
+
+    async def _async_train_request(self, request: TrainingRequest):
+        """Call the speaker-recognition backend training API off the HA event loop."""
+
+        def _train_in_thread():
+            client = SpeakerRecognitionClient(base_url=self.base_url, timeout=300.0)
+            return asyncio.run(client.train(request))
+
+        return await self.hass.async_add_executor_job(_train_in_thread)
+
+    async def _async_recognize_request(self, request: RecognitionRequest):
+        """Call the speaker-recognition backend recognition API off the HA event loop."""
+
+        def _recognize_in_thread():
+            client = SpeakerRecognitionClient(base_url=self.base_url, timeout=300.0)
+            return asyncio.run(client.recognize(request))
+
+        return await self.hass.async_add_executor_job(_recognize_in_thread)
 
     async def async_train(self) -> None:
         """Train the speaker recognition model with configured voice samples."""
@@ -59,17 +146,37 @@ class SpeakerRecognition:
 
         try:
             voice_sample_models = []
+
             for sample in self.voice_samples:
-                user_id = sample["user"]
-                media_id = sample["samples"].get("media_content_id", "")
+                if not isinstance(sample, dict):
+                    _LOGGER.warning("Invalid voice sample entry: %r", sample)
+                    continue
 
-                if media_id.startswith("media-source://media_source/local/"):
-                    relative_path = media_id.replace(
-                        "media-source://media_source/local/", ""
+                user_id = sample.get("user")
+                if not isinstance(user_id, str) or not user_id:
+                    _LOGGER.warning("Invalid voice sample user: %r", user_id)
+                    continue
+
+                media = _extract_media_object(sample)
+                if media is None:
+                    _LOGGER.warning(
+                        "Skipping invalid voice sample media for user %s",
+                        user_id,
                     )
-                    full_path = Path(self.hass.config.path("media")) / relative_path
+                    continue
 
-                    # Read the audio file
+                media_id = media.get("media_content_id", "")
+                if not isinstance(media_id, str):
+                    _LOGGER.warning(
+                        "Invalid media_content_id for user %s: %r",
+                        user_id,
+                        media_id,
+                    )
+                    continue
+
+                if media_id.startswith(LOCAL_MEDIA_PREFIX):
+                    full_path = _resolve_local_media_path(self.hass, media_id)
+
                     audio_data = await self.hass.async_add_executor_job(
                         full_path.read_bytes
                     )
@@ -85,7 +192,11 @@ class SpeakerRecognition:
                         )
                     )
                 else:
-                    _LOGGER.warning("Unsupported media_content_id format: %s", media_id)
+                    _LOGGER.warning(
+                        "Unsupported media_content_id format for user %s: %s",
+                        user_id,
+                        media_id,
+                    )
                     continue
 
             if not voice_sample_models:
@@ -94,29 +205,29 @@ class SpeakerRecognition:
                 return
 
             request = TrainingRequest(voice_samples=voice_sample_models)
-            result = await self._client.train(request)
+            result = await self._async_train_request(request)
 
         except (OSError, ValueError, TypeError) as error:
             _LOGGER.error("Error during training: %s", error)
             self._trained = False
+
         else:
             self._trained = True
-            _LOGGER.info(
-                "Speaker recognition training completed: %d users trained",
-                result.users_trained,
-            )
+            _LOGGER.info("Speaker recognition training completed")
 
     async def async_recognize(
-        self, audio_data: bytes, sample_rate: int = 16000
+        self,
+        audio_data: bytes,
+        sample_rate: int = 16000,
     ) -> RecognitionResult | None:
         """Recognize speaker from audio data.
 
         Args:
-            audio_data: Raw audio data to analyze (PCM 16-bit)
-            sample_rate: Audio sample rate
+            audio_data: Raw audio data to analyze.
+            sample_rate: Audio sample rate.
 
         Returns:
-            RecognitionResult if a speaker is recognized, None otherwise
+            RecognitionResult if a speaker is recognized, None otherwise.
         """
         if not self._trained:
             _LOGGER.debug("Speaker recognition not trained yet")
@@ -124,33 +235,31 @@ class SpeakerRecognition:
 
         try:
             audio_base64 = base64.b64encode(audio_data).decode("utf-8")
-
             request = RecognitionRequest(
                 audio=AudioInput(
                     audio_data=audio_base64,
                     sample_rate=sample_rate,
                 )
             )
-
-            result = await self._client.recognize(request)
+            result = await self._async_recognize_request(request)
 
         except (OSError, ValueError, TypeError) as error:
             _LOGGER.error("Error during recognition: %s", error)
             return None
+
         else:
             _LOGGER.debug(
                 "Recognition result: user=%s, confidence=%.2f",
                 result.user_id,
                 result.confidence,
             )
-
             return result
 
     def update_voice_samples(self, voice_samples: list[dict]) -> None:
         """Update voice samples and mark as needing retraining.
 
         Args:
-            voice_samples: New list of voice samples
+            voice_samples: New list of voice samples.
         """
         self.voice_samples = voice_samples
         self._trained = False

--- a/custom_components/speaker_recognition/stt.py
+++ b/custom_components/speaker_recognition/stt.py
@@ -83,6 +83,7 @@ class SpeakerRecognitionSTTEntity(SpeechToTextEntity):
         """Initialize the STT entity."""
         registry = er.async_get(hass)
         device_registry = dr.async_get(hass)
+
         wrapped_stt = registry.async_get(stt_entity_id)
         device_id = wrapped_stt.device_id if wrapped_stt else None
         entity_category = wrapped_stt.entity_category if wrapped_stt else None
@@ -103,6 +104,7 @@ class SpeakerRecognitionSTTEntity(SpeechToTextEntity):
         self._attr_has_entity_name = has_entity_name
         self._attr_name = name
         self._attr_unique_id = unique_id
+
         self._stt_entity_id = stt_entity_id
         self._main_entry = main_entry
 
@@ -136,9 +138,10 @@ class SpeakerRecognitionSTTEntity(SpeechToTextEntity):
             self._attr_available = False
         else:
             self._attr_available = True
-            # Update cached properties if not yet set
-            if self._cached_languages is None:
-                self._async_update_properties()
+
+        # Update cached properties if not yet set
+        if self._cached_languages is None:
+            self._async_update_properties()
 
     async def async_added_to_hass(self) -> None:
         """Handle entity added to hass."""
@@ -205,7 +208,6 @@ class SpeakerRecognitionSTTEntity(SpeechToTextEntity):
         """
         # Get the source entity - it should be available if we're being called
         source_entity = async_get_speech_to_text_entity(self.hass, self._stt_entity_id)
-
         if source_entity is None:
             # Entity not found - return error
             return SpeechResult(None, SpeechResultState.ERROR)
@@ -228,19 +230,21 @@ class SpeakerRecognitionSTTEntity(SpeechToTextEntity):
         if audio_buffer:
             try:
                 recognition_result = await self.recognition.async_recognize(
-                    bytes(audio_buffer), sample_rate=metadata.sample_rate
+                    bytes(audio_buffer),
+                    sample_rate=metadata.sample_rate,
                 )
 
                 if recognition_result:
-                    # Log the recognition result as error for now
-                    _LOGGER.error(
+                    all_scores = {
+                        user: f"{score:.3f}"
+                        for user, score in recognition_result.all_scores.items()
+                    }
+
+                    _LOGGER.info(
                         "Speaker Recognition Result - User: %s, Confidence: %.3f, All scores: %s",
                         recognition_result.user_id,
                         recognition_result.confidence,
-                        {
-                            user: f"{score:.3f}"
-                            for user, score in recognition_result.all_scores.items()
-                        },
+                        all_scores,
                     )
 
                     # Fire an event with the recognition result
@@ -254,16 +258,20 @@ class SpeakerRecognitionSTTEntity(SpeechToTextEntity):
                         },
                     )
 
-                    # Store the most recent recognition result for potential conversation use
+                    # Store the most recent recognition result for conversation use
                     if "speaker_recognition" not in self.hass.data:
                         self.hass.data["speaker_recognition"] = {}
+
                     self.hass.data["speaker_recognition"]["last_result"] = {
                         "user_id": recognition_result.user_id,
                         "confidence": recognition_result.confidence,
                         "timestamp": self.hass.loop.time(),
+                        "entity_id": self.entity_id,
+                        "all_scores": recognition_result.all_scores,
                     }
                 else:
-                    _LOGGER.error("Speaker recognition returned no result")
+                    _LOGGER.warning("Speaker recognition returned no result")
+
             except (OSError, ValueError, TypeError) as error:
                 _LOGGER.error("Error during speaker recognition: %s", error)
 


### PR DESCRIPTION
## Summary

This PR improves reliability of the Home Assistant custom integration runtime recognition path.

The changes are intentionally limited to:

- `custom_components/speaker_recognition/recognition.py`
- `custom_components/speaker_recognition/stt.py`

This avoids mixing runtime reliability fixes with UI, branding, config-flow, or conversation-agent behavior changes.

## What changed

### Media source file resolution

The integration now resolves Home Assistant local media-source voice samples from both:

- `/media/<relative path>`
- `hass.config.path("media")/<relative path>`

It also URL-decodes the local media-source path before resolving it.

This makes voice sample training more reliable across Home Assistant OS/container layouts where the selected media file may exist under `/media` rather than only under Home Assistant's configured media path.

### Defensive voice sample handling

The training path now validates configured voice sample entries before using them.

It also accepts the older one-item list shape for the media selector value, while rejecting invalid, empty, or multi-file values.

This helps avoid breaking existing saved options if the selector shape changed or if older configuration data is still present.

### Avoid blocking the Home Assistant event loop

Backend train and recognize calls are now run through Home Assistant's executor instead of being awaited directly in the entity's async path.

This prevents backend/client work from running directly on Home Assistant's event loop.

### Training result handling

The training path no longer depends on a specific `TrainingResult.users_trained` response attribute.

The previous logging assumed that field existed, but the installed/backend client may not expose it consistently.

### Logging cleanup

Successful speaker recognition is now logged at info level instead of error level.

Actual exceptions during recognition are still logged as errors.

A recognition attempt returning no result is logged as a warning instead of an error.

## Why

These changes make the Home Assistant integration more tolerant of real Home Assistant media paths, older saved selector data, backend response differences, and blocking backend calls.

They also make logs clearer by avoiding error-level messages for successful recognition.

## Testing

Tested locally in Home Assistant with the speaker recognition STT proxy and conversation proxy.

Observed behavior:

- Integration loads successfully.
- Voice samples train successfully from Home Assistant local media.
- Recognition runs after STT processing.
- `speaker_recognition_detected` events are still fired.
- Last recognition result is still stored in `hass.data` for conversation use.
- Successful recognition is no longer logged as an error.

Also ran:

```bash
python3 -m py_compile \
  custom_components/speaker_recognition/recognition.py \
  custom_components/speaker_recognition/stt.py

python3 -m compileall custom_components/speaker_recognition